### PR TITLE
fix: partial revert of 1be7c1a20; make traverser process identity CIDs

### DIFF
--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -352,8 +352,8 @@ func TestGraphsyncIdentityCIDRoundTrip(t *testing.T) {
 	})
 	progressChan, errChan := requestor.Request(ctx, td.host2.ID(), identityDag.RootLink, selectorparse.CommonSelector_ExploreAllRecursively)
 
-	identityDag.VerifyWholeDAG(ctx, progressChan)
 	testutil.VerifyEmptyErrors(ctx, t, errChan)
+	identityDag.VerifyWholeDAG(ctx, progressChan)
 	require.Len(t, td.blockStore1, len(identityDag.AllLinks), "did not store all blocks")
 
 	// verify listener

--- a/ipldutil/traverser.go
+++ b/ipldutil/traverser.go
@@ -1,20 +1,17 @@
 package ipldutil
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
 	"sync"
 
-	"github.com/ipfs/go-cid"
 	dagpb "github.com/ipld/go-codec-dagpb"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
 	"github.com/ipld/go-ipld-prime/traversal"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
-	"github.com/multiformats/go-multihash"
 
 	"github.com/filecoin-project/boost-graphsync/panics"
 )
@@ -168,23 +165,7 @@ func (t *traverser) NBlocksTraversed() int {
 	return t.blocksCount
 }
 
-func asIdentity(c cid.Cid) (digest []byte, ok bool, err error) {
-	dmh, err := multihash.Decode(c.Hash())
-	if err != nil {
-		return nil, false, err
-	}
-	ok = dmh.Code == multihash.IDENTITY
-	digest = dmh.Digest
-	return digest, ok, nil
-}
-
 func (t *traverser) loader(lnkCtx ipld.LinkContext, lnk ipld.Link) (io.Reader, error) {
-	if digest, ok, err := asIdentity(lnk.(cidlink.Link).Cid); ok {
-		return io.NopCloser(bytes.NewReader(digest)), nil
-	} else if err != nil {
-		return nil, err
-	}
-
 	// A StorageReadOpener call came in; update the state and release the lock.
 	// We can't simply unlock the mutex inside the <-t.responses case,
 	// as then we'd deadlock with the other side trying to send.


### PR DESCRIPTION
_(port of https://github.com/ipfs/go-graphsync/pull/442)_

It turns out that there are obscure cases where this matters, so we can't as easily just ignore identity CIDs. Specifically, classic online Filecoin deals that rely on Graphsync _and_ require identity CIDs be stored in the CARv1 that is used to calculate CommP must see the identity CID pass through the LinkSystem.

Unfortunately, the easiest way to deal with this is to send them over the wire as if they are a normal block; which happens to be the "safe" backward compatible way too. Less easy way would be to simulate it on both ends and not send them, but we'll take the easy path for now.

Extension of tests in here to make sure that the full DAG is transferred even in this case. Blockstore _must_ have identity CIDs in them, or be able to respond properly to them.