### PR TITLE
fix peer ID string

### DIFF
--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -7,7 +7,7 @@ import (
 
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipfs/go-peertaskqueue"
-	ipld "github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -318,7 +318,7 @@ func (gs *GraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link, sel
 		extNames = append(extNames, string(ext.Name))
 	}
 	ctx, _ = otel.Tracer("graphsync").Start(ctx, "request", trace.WithAttributes(
-		attribute.String("peerID", p.Pretty()),
+		attribute.String("peerID", p.String()),
 		attribute.String("root", root.String()),
 		attribute.StringSlice("extensions", extNames),
 	))

--- a/requestmanager/server.go
+++ b/requestmanager/server.go
@@ -289,7 +289,7 @@ func (rm *RequestManager) processResponses(p peer.ID,
 		requestIds = append(requestIds, r.RequestID().String())
 	}
 	ctx, span := otel.Tracer("graphsync").Start(rm.ctx, "processResponses", trace.WithAttributes(
-		attribute.String("peerID", p.Pretty()),
+		attribute.String("peerID", p.String()),
 		attribute.StringSlice("requestIDs", requestIds),
 		attribute.Int("blockCount", len(blks)),
 	))

--- a/responsemanager/server.go
+++ b/responsemanager/server.go
@@ -184,7 +184,7 @@ func (rm *ResponseManager) processRequests(p peer.ID, requests []gsmsg.GraphSync
 	ctx, messageSpan := otel.Tracer("graphsync").Start(
 		rm.ctx,
 		"processRequests",
-		trace.WithAttributes(attribute.String("peerID", p.Pretty())),
+		trace.WithAttributes(attribute.String("peerID", p.String())),
 	)
 	defer messageSpan.End()
 


### PR DESCRIPTION
This PR removed the deprecated method Pretty() for the peer ID.